### PR TITLE
added clamAv version 1.8 to list of docker images

### DIFF
--- a/base-image-import.yml
+++ b/base-image-import.yml
@@ -27,7 +27,13 @@ jobs:
     name: hmcts-cftptl-agent-pool
   strategy:
     maxParallel: 2
-    matrix: 
+    matrix:
+      clamav-18-mailu:
+        baseImage: mailu/clamav
+        baseRegistry: docker.io
+        baseTag: 1.8
+        baseImageType: docker  # docker or gcr
+        targetImage: imported/mailu/clamav
       node-10-alpine:
         baseImage: library/node
         baseRegistry: docker.io


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/EM-3390

### Change description ###
Add mailu/clamav image to hmcts ACR repo as it is used by the wiremind helm chart https://artifacthub.io/packages/helm/wiremind/clamav

as advised by Tim J - https://hmcts-reform.slack.com/archives/C6DN09J8G/p1614954156009100

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
