### PR TITLE
added mock clamAv from citizens advice

### DIFF
--- a/base-image-import.yml
+++ b/base-image-import.yml
@@ -34,6 +34,12 @@ jobs:
         baseTag: 1.8
         baseImageType: docker  # docker or gcr
         targetImage: imported/mailu/clamav
+      clamav-mock-100-citizensadvice:
+        baseImage: citizensadvice/clamav-mock
+        baseRegistry: docker.io
+        baseTag: 1.0.0
+        baseImageType: docker  # docker or gcr
+        targetImage: imported/citizensadvice/clamav-mock
       node-10-alpine:
         baseImage: library/node
         baseRegistry: docker.io


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/EM-3390


### Change description ###

Add citizensadvice/clamav-mock image to hmcts ACR repo as it is used during integration testing (saves 300mb download of virus definitions)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
