### PR TITLE
Force image update

### DIFF
--- a/base-image-import.yml
+++ b/base-image-import.yml
@@ -134,18 +134,18 @@ jobs:
       keyVaultName: $(keyvaultNameStg)
       secretsFilter: 'neuvector-admin-username,neuvector-new-admin-password'
   
-  - task: AzureCLI@1
-    displayName: 'Check base registry if new digest available for tag'
-    inputs:
-      azureSubscription: $(serviceConnection)
-      scriptLocation: 'scriptPath'
-      scriptPath: check-base-tag.sh
-      arguments: |
-        "$(baseImage)" "$(baseRegistry)" "$(baseTag)" "$(targetImage)" "$(baseImageType)" "$(acrName)"
+#   - task: AzureCLI@1
+#     displayName: 'Check base registry if new digest available for tag'
+#     inputs:
+#       azureSubscription: $(serviceConnection)
+#       scriptLocation: 'scriptPath'
+#       scriptPath: check-base-tag.sh
+#       arguments: |
+#         "$(baseImage)" "$(baseRegistry)" "$(baseTag)" "$(targetImage)" "$(baseImageType)" "$(acrName)"
 
   - task: AzureCLI@1
     displayName: 'Import docker image'
-    condition: eq(variables['newTagFound'], 'true')
+    #condition: eq(variables['newTagFound'], 'true')
     inputs:
       azureSubscription: $(serviceConnection)
       scriptLocation: 'inlineScript'
@@ -169,7 +169,7 @@ jobs:
   - task: AzureCLI@1
     displayName: 'Re-tag new image using the base tag'
 #    condition: and(eq(variables['newTagFound'], 'true'), eq(variables['scanPassed'], 'true'))
-    condition: eq(variables['newTagFound'], 'true')
+#    condition: eq(variables['newTagFound'], 'true')
     inputs:
       azureSubscription: $(serviceConnection)
       scriptLocation: 'scriptPath'

--- a/base-image-import.yml
+++ b/base-image-import.yml
@@ -134,14 +134,14 @@ jobs:
       keyVaultName: $(keyvaultNameStg)
       secretsFilter: 'neuvector-admin-username,neuvector-new-admin-password'
   
-#   - task: AzureCLI@1
-#     displayName: 'Check base registry if new digest available for tag'
-#     inputs:
-#       azureSubscription: $(serviceConnection)
-#       scriptLocation: 'scriptPath'
-#       scriptPath: check-base-tag.sh
-#       arguments: |
-#         "$(baseImage)" "$(baseRegistry)" "$(baseTag)" "$(targetImage)" "$(baseImageType)" "$(acrName)"
+  - task: AzureCLI@1
+    displayName: 'Check base registry if new digest available for tag'
+    inputs:
+      azureSubscription: $(serviceConnection)
+      scriptLocation: 'scriptPath'
+      scriptPath: check-base-tag.sh
+      arguments: |
+        "$(baseImage)" "$(baseRegistry)" "$(baseTag)" "$(targetImage)" "$(baseImageType)" "$(acrName)"
 
   - task: AzureCLI@1
     displayName: 'Import docker image'


### PR DESCRIPTION
After switching preview to AKS 1.25 we've had a mass report of issues with Java containers not starting.

This is most likely due to cgroups v2 GA'ing in 1.25.
Preview images have less resources associated to them.

The JVM is not correctly adapting container resources as it doesn't know about cgroups v2

This was backported to Java 11 in 11.0.16 https://bugs.openjdk.org/browse/JDK-8283559

It appears that we've been stuck on 11.0.14 without realising it.

```
$ docker pull hmctspublic.azurecr.io/base/java:11-distroless
$ docker run -it hmctspublic.azurecr.io/base/java:11-distroless -version
openjdk version "11.0.14" 2022-01-18
```

Upstream:
```
$ docker pull gcr.io/distroless/java11-debian11
$ docker run -it  gcr.io/distroless/java11-debian11 -version
openjdk version "11.0.18" 2023-01-17
```