### PR TITLE
remove mailu/clamav

### DIFF
--- a/base-image-import.yml
+++ b/base-image-import.yml
@@ -28,11 +28,6 @@ jobs:
   strategy:
     maxParallel: 5
     matrix:
-      clamav-18-mailu:
-        baseImage: mailu/clamav
-        baseRegistry: docker.io
-        baseTag: 1.8
-        targetImage: imported/mailu/clamav
       clamav-mock-100-citizensadvice:
         baseImage: citizensadvice/clamav-mock
         baseRegistry: docker.io


### PR DESCRIPTION
ERROR: pull access denied, repository does not exist or may require authorization
This is because mailu images were removed from docker.io and moved to ghcr.io (but only 2.X versions are available - 1.8 couldn't be used - so I investigated whether this was actually in use).

This was added for https://tools.hmcts.net/jira/browse/EM-3390 - ticket was withdrawn as PA was decided on.

Context: https://hmcts-reform.slack.com/archives/C6DN09J8G/p1614954156009100

 
**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
