### PR TITLE
DTSPO-14807 implement cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ To create a new ACR cache rule on a repository you need to amend the [yaml file]
     ruleName: Jenkins # the name of the cache rule
     repoName: hmcts/jenkins # the name of the repository the image is stored in
     destinationRepo: jenkins # destination repository as it appears in Azure hmctspublic ACR, which the cache rule will be associated to and which will make up the URL to fetch the image. Will create a new repository if one does not exist.
-    tagVersion: "75c3e8818c" # The version of the image you need to pull into the Cache; before the image can be used in the cache it needs to be pulled into it by the pipeline
+    # Array of images that need pulling into the repository
+    images: 
+      - "75c3e8818c" # The version of the image you need to pull into the Cache; before the image can be used in the cache it needs to be pulled into it by the pipeline
+      - ...
 ```
 
 The pipeline will also pull the docker image with the tag specified above into the cache.

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # acr-base-importer
 Pipelines to automatically import updates to base images and scan them for vulnerabilities
 
-# ACR Cache
-The pipeline will also create ACR Caches into hmctspublic registry.
+# ACR Cache Rules
+The pipeline will also create and add ACR Cache Rules into hmctspublic registry.
 
-To create a new ACR cache on a repository you need to amend the acr-repositories.yaml file, to add the required details of the new cache. You need to add the following block of code, replacing the values of the parameters with the one you need creating. The below is just an example of an existing ACR Cache
+To create a new ACR cache rule on a repository you need to amend the [yaml file](acr-repositories.yaml), to add the required details of the new cache rule. You need to add the following block of code, replacing the values of the parameters with the one you need creating. The below is just an example of an existing ACR Cache rule:
  
  ```
   jenkins: # this can be the same as the name of the repository
     ruleName: Jenkins # the name of the cache rule
-    repoName: hmcts/jenkins # the name of the repository
-    destinationRepo: jenkins # destination repository as it appears in the ACR Cache
+    repoName: hmcts/jenkins # the name of the repository the image is stored in
+    destinationRepo: jenkins # destination repository as it appears in Azure hmctspublic ACR, which the cache rule will be associated to
     tagVersion: "75c3e8818c" # The version of the image you need to pull into the Cache; before the image can be used in the cache it needs to be pulled into it by the pipeline
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To create a new ACR cache rule on a repository you need to amend the [yaml file]
   jenkins: # this can be the same as the name of the repository
     ruleName: Jenkins # the name of the cache rule
     repoName: hmcts/jenkins # the name of the repository the image is stored in
-    destinationRepo: jenkins # destination repository as it appears in Azure hmctspublic ACR, which the cache rule will be associated to
+    destinationRepo: jenkins # destination repository as it will appear in Azure hmctspublic ACR, which the cache rule will be associated to. This will make part of the URL used to fetch the cached image.
     tagVersion: "75c3e8818c" # The version of the image you need to pull into the Cache; before the image can be used in the cache it needs to be pulled into it by the pipeline
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To create a new ACR cache rule on a repository you need to amend the [yaml file]
   jenkins: # this can be the same as the name of the repository
     ruleName: Jenkins # the name of the cache rule
     repoName: hmcts/jenkins # the name of the repository the image is stored in
-    destinationRepo: jenkins # destination repository as it will appear in Azure hmctspublic ACR, which the cache rule will be associated to. This will make part of the URL used to fetch the cached image.
+    destinationRepo: jenkins # destination repository as it appears in Azure hmctspublic ACR, which the cache rule will be associated to and which will make up the URL to fetch the image. Will create a new repository if one does not exist.
     tagVersion: "75c3e8818c" # The version of the image you need to pull into the Cache; before the image can be used in the cache it needs to be pulled into it by the pipeline
 ```
 

--- a/acr-cache.sh
+++ b/acr-cache.sh
@@ -16,6 +16,8 @@ for key in $(echo $RULES_CONFIG | jq -r '.rules | keys | .[]'); do
     echo "Creating ACR Cache for $key"
     az acr cache create -r hmctspublic -n $RULE_NAME -s docker.io/$REPO_NAME -t $DESTINATION_NAME
 
+
+    # Repository in ACR (if new) will not be created until docker pull command has been run for first time
     echo "Docker Image Pull"
     docker pull hmctspublic.azurecr.io/$DESTINATION_NAME:$TAG_VERSION
 done

--- a/acr-cache.sh
+++ b/acr-cache.sh
@@ -11,13 +11,17 @@ for key in $(echo $RULES_CONFIG | jq -r '.rules | keys | .[]'); do
     RULE_NAME=$(echo $RULES_CONFIG | jq -r '.rules | ."'$key'" | .ruleName')
     REPO_NAME=$(echo $RULES_CONFIG | jq -r '.rules | ."'$key'" | .repoName')
     DESTINATION_NAME=$(echo $RULES_CONFIG | jq -r '.rules | ."'$key'" | .destinationRepo')
-    TAG_VERSION=$(echo $RULES_CONFIG | jq -r '.rules | ."'$key'" | .tagVersion')
+    IMAGES=$(echo $RULES_CONFIG | jq -r '.rules | ."'$key'" | .images')
 
     echo "Creating ACR Cache for $key"
     az acr cache create -r hmctspublic -n $RULE_NAME -s docker.io/$REPO_NAME -t $DESTINATION_NAME
 
 
     # Repository in ACR (if new) will not be created until docker pull command has been run for first time
-    echo "Docker Image Pull"
-    docker pull hmctspublic.azurecr.io/$DESTINATION_NAME:$TAG_VERSION
+    echo "Docker Image Pull to populate repositories with external images"
+    # Fetch images from returned array and remove speech marks
+    echo $IMAGES | jq -c '.[]' |  tr -d '"' | while read image; do
+        echo "Pulling $image into $DESTINATION_NAME repository for use with cache rule..."
+        docker pull hmctspublic.azurecr.io/$DESTINATION_NAME:$image
+    done
 done

--- a/acr-repositories.yaml
+++ b/acr-repositories.yaml
@@ -4,3 +4,8 @@ rules:
     repoName: bitnami/postgresql
     destinationRepo: imported/bitnami/postgresql
     tagVersion: 11.16.0
+  external-dns: 
+    ruleName: external-dns
+    repoName: bitnami/external-dns
+    destinationRepo: imported/bitnami/external-dns
+    tagVersion: 0.13.3-debian-11-r3

--- a/acr-repositories.yaml
+++ b/acr-repositories.yaml
@@ -3,9 +3,14 @@ rules:
     ruleName: postgresql
     repoName: bitnami/postgresql
     destinationRepo: imported/bitnami/postgresql
-    tagVersion: 11.16.0
+    images:
+      - 11.16.0
+      - 11.3.0
+      - 11.6.0
   external-dns: 
     ruleName: external-dns
     repoName: bitnami/external-dns
     destinationRepo: imported/bitnami/external-dns
-    tagVersion: 0.13.3-debian-11-r3
+    images:
+      - 0.13.3-debian-11-r3
+      - 0.13.2-debian-11-r11


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-14807

Add:
  - Functionality to add multiple images to the new repo that will be created (docker pull previously added the one specified tag version) -- new repo with assigned cache rule is only created after the docker pull command has been ran

Update:
  - Minor wording in the documentation
  - Structure of YAML object in the example
  - Other images that existed in postgresql repo, that didn't exist here




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
