### PR TITLE
Update readme, remove image pull, add repo table

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,16 @@
 # acr-base-importer
 Pipelines to automatically import updates to base images and scan them for vulnerabilities
+## Supported Upstream Image Repositories
 
-# ACR Cache Rules
+Below is a table of upstream image repositories that will have supported cache rules in hmctspublic. No image tags are added by default, but will be added on the first running instance of `docker pull hmctspublic.azurecr.io/${destinationRepo}:image-tag`, where destinationRepo is the [mapped repository in our ACR for the upstream repository](acr-respositories.yaml), any upstream image tag is available.
+
+
+| **Upstream Repository Name**  | **HMCTS Repository Name** |
+| -------- | ------- |
+| bitnami/postgresql  | hmctspublic.azurecr.io/imported/bitnami/postgresql    |
+
+
+### ACR Cache Rules
 The pipeline will also add ACR Cache Rules into hmctspublic registry.
 
 To create a new ACR cache rule on a repository you need to amend the [yaml file](acr-repositories.yaml), to add the required details of the new cache rule. You need to add the following block of code, replacing the values of the parameters with the one you need creating. The below is just an example of an existing ACR Cache rule
@@ -12,12 +21,3 @@ To create a new ACR cache rule on a repository you need to amend the [yaml file]
     repoName: hmcts/jenkins # the name of the repository the image is currently stored in
     destinationRepo: jenkins # destination repository as it appears in the ACR Cache, will not be visibile until first instance of docker pull command
  ```
-
-# Supported Upstream Image Repositories
-
-Below is a table of upstream image repositories that will have supported cache rules in hmctspublic. No image tags are added by default, but will be added on the first running instance of `docker pull hmctspublic.azurecr.io/${destinationRepo}:image-tag`, where destinationRepo is the [mapped repository in our ACR for the upstream repository](acr-respositories.yaml), any upstream image tag is available.
-
-
-| **Upstream Repository Name**  | **HMCTS Repository Name** |
-| -------- | ------- |
-| bitnami/postgresql  | imported/bitnami/postgresql    |

--- a/README.md
+++ b/README.md
@@ -7,37 +7,37 @@ Below is a table of upstream image repositories that will have supported cache r
 
 | **Upstream Repository Name**  | **HMCTS Repository Name** |
 | -------- | ------- |
-| bitnami/external-dns               | hmctspublic.azurecr.io/imported/bitnami/external-dns    |
-| bitnami/kubectl                    | hmctspublic.azurecr.io/imported/bitnami/kubectl         |
-| bitnami/postgresql                 | hmctspublic.azurecr.io/imported/bitnami/postgresql      |
-| bitnami/redis                      | hmctspublic.azurecr.io/imported/bitnami/redis           |
-| datawire/tel2                      | hmctspublic.azurecr.io/imported/datawire/tel2           |
-| dius/pact-broker                   | hmctspublic.azurecr.io/imported/dius/pact-broker        |
-| drycc/service-catalog              | hmctspublic.azurecr.io/imported/dyrcc/service-catalog   |
-| dynatrace/dynatrace-operator       | hmctspublic.azurecr.io/imported/dynatrace/dynatrace-operator|
-| fluent/fluent-bit                  | hmctspublic.azurecr.io/imported/fluent/fluent-bit       |
-| grafana/grafana                    | hmctspublic.azurecr.io/imported/grafana                 |
-| jimmidyson/configmap-reload        | hmctspublic.azurecr.io/imported/jimmidyson/configmap-reload|
-| kiwigrid/k8s-sidecar               | hmctspublic.azurecr.io/imported/kiwigrid/k8s-sidecar    |
-| kubeshop/testkube-api-server       | hmctspublic.azurecr.io/imported/kubeshop/testkube-api-server|
-| kubeshop/testkube-dashboard        | hmctspublic.azurecr.io/imported/kubeshop/testkube-dashboard|
-| kubeshop/testkube-operator         | hmctspublic.azurecr.io/imported/kubeshop/testkube-operator|
-| linuxserver/openssh-server         | hmctspublic.azurecr.io/imported/linuxserver/openssh-server|
-| mailhog/mailhog                    | hmctspublic.azurecr.io/imported/mailhog/mailhog          |
-| minio/minio                        | hmctspublic.azurecr.io/imported/minio/minio              |
-| nats                               | hmctspublic.azurecr.io/imported/nats                    |
-| natsio/nats-server-config-reloader | hmctspublic.azurecr.io/imported/natsio/nats-server-config-reloader|
-| natsio/prometheus-nats-exporter    | hmctspublic.azurecr.io/imported/natsio/prometheus-nats-exporter|
-| neuvector/controller               | hmctspublic.azurecr.io/imported/neuvector/controller    |
-| neuvector/enforcer                 | hmctspublic.azurecr.io/imported/neuvector/enforcer      |
-| neuvector/manager                  | hmctspublic.azurecr.io/imported/neuvector/manager       |
-| neuvector/updater                  | hmctspublic.azurecr.io/imported/neuvector/updater       |
-| netboxcommunity/netbox             | hmctspublic.azurecr.io/imported/netboxcommunity/netbox  |
-| nginx                              | hmctspublic.azurecr.io/imported/nginx                   |
-| otel/opentelemetry-collector-contrib| hmctspublic.azurecr.io/imported/otel/opentelemetry-collector/contrib|
-| prom/node-exporter                 | hmctspublic.azurecr.io/imported/prom/node-exporter       |
-| traefik                            | hmctspublic.azurecr.io/imported/traefik                 |
-| willwill/kube-slack                | hmctspublic.azurecr.io/imported/willwill/kube-slack     |
+| `bitnami/external-dns`               | `hmctspublic.azurecr.io/imported/bitnami/external-dns`    |
+| `bitnami/kubectl`                    | `hmctspublic.azurecr.io/imported/bitnami/kubectl`         |
+| `bitnami/postgresql`                 | `hmctspublic.azurecr.io/imported/bitnami/postgresql`      |
+| `bitnami/redis`                      | `hmctspublic.azurecr.io/imported/bitnami/redis`           |
+| `datawire/tel2`                      | `hmctspublic.azurecr.io/imported/datawire/tel2`           |
+| `dius/pact-broker`                   | `hmctspublic.azurecr.io/imported/dius/pact-broker`        |
+| `drycc/service-catalog`              | `hmctspublic.azurecr.io/imported/dyrcc/service-catalog`   |
+| `dynatrace/dynatrace-operator`       | `hmctspublic.azurecr.io/imported/dynatrace/dynatrace-operator` |
+| `fluent/fluent-bit`                  | `hmctspublic.azurecr.io/imported/fluent/fluent-bit`       |
+| `grafana/grafana`                    | `hmctspublic.azurecr.io/imported/grafana`                 |
+| `jimmidyson/configmap-reload`        | `hmctspublic.azurecr.io/imported/jimmidyson/configmap-reload` |
+| `kiwigrid/k8s-sidecar`               | `hmctspublic.azurecr.io/imported/kiwigrid/k8s-sidecar`    |
+| `kubeshop/testkube-api-server`       | `hmctspublic.azurecr.io/imported/kubeshop/testkube-api-server` |
+| `kubeshop/testkube-dashboard`        | `hmctspublic.azurecr.io/imported/kubeshop/testkube-dashboard` |
+| `kubeshop/testkube-operator`         | `hmctspublic.azurecr.io/imported/kubeshop/testkube-operator`|
+| `linuxserver/openssh-server`         | `hmctspublic.azurecr.io/imported/linuxserver/openssh-server` | 
+| `mailhog/mailhog`                    | `hmctspublic.azurecr.io/imported/mailhog/mailhog`          |
+| `minio/minio`                        | `hmctspublic.azurecr.io/imported/minio/minio`              |
+| `nats`                               | `hmctspublic.azurecr.io/imported/nats`                   |
+| `natsio/nats-server-config-reloader` | `hmctspublic.azurecr.io/imported/natsi/nats-server-config-reloader` |
+| `natsio/prometheus-nats-exporter`    | `hmctspublic.azurecr.io/imported/natsio/prometheus-nats-exporter` |
+| `neuvector/controller`               | `hmctspublic.azurecr.io/imported/neuvector/controller`    |
+| `neuvector/enforcer`                 | `hmctspublic.azurecr.io/imported/neuvector/enforcer`      |
+| `neuvector/manager`                  | `hmctspublic.azurecr.io/imported/neuvector/manager`       |
+| `neuvector/updater`                  | `hmctspublic.azurecr.io/imported/neuvector/updater`       |
+| `netboxcommunity/netbox`             | `hmctspublic.azurecr.io/imported/netboxcommunity/netbox`  |
+| `nginx`                              | `hmctspublic.azurecr.io/imported/nginx`                   |
+| `otel/opentelemetry-collector-contrib` | `hmctspublic.azurecr.io/imported/otel/opentelemetry-collector/contrib` |
+| `prom/node-exporter`                 | `hmctspublic.azurecr.io/imported/prom/node-exporter`       |
+| `traefik`                            | `hmctspublic.azurecr.io/imported/traefik`                 |
+| `willwill/kube-slack`                | `hmctspublic.azurecr.io/imported/willwill/kube-slack`     |
 
 ### ACR Cache Rules
 The pipeline will also add ACR Cache Rules into hmctspublic registry.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,37 @@ Below is a table of upstream image repositories that will have supported cache r
 
 | **Upstream Repository Name**  | **HMCTS Repository Name** |
 | -------- | ------- |
-| bitnami/postgresql  | hmctspublic.azurecr.io/imported/bitnami/postgresql    |
-
+| bitnami/external-dns               | hmctspublic.azurecr.io/imported/bitnami/external-dns    |
+| bitnami/kubectl                    | hmctspublic.azurecr.io/imported/bitnami/kubectl         |
+| bitnami/postgresql                 | hmctspublic.azurecr.io/imported/bitnami/postgresql      |
+| bitnami/redis                      | hmctspublic.azurecr.io/imported/bitnami/redis           |
+| datawire/tel2                      | hmctspublic.azurecr.io/imported/datawire/tel2           |
+| dius/pact-broker                   | hmctspublic.azurecr.io/imported/dius/pact-broker        |
+| drycc/service-catalog              | hmctspublic.azurecr.io/imported/dyrcc/service-catalog   |
+| dynatrace/dynatrace-operator       | hmctspublic.azurecr.io/imported/dynatrace/dynatrace-operator|
+| fluent/fluent-bit                  | hmctspublic.azurecr.io/imported/fluent/fluent-bit       |
+| grafana/grafana                    | hmctspublic.azurecr.io/imported/grafana                 |
+| jimmidyson/configmap-reload        | hmctspublic.azurecr.io/imported/jimmidyson/configmap-reload|
+| kiwigrid/k8s-sidecar               | hmctspublic.azurecr.io/imported/kiwigrid/k8s-sidecar    |
+| kubeshop/testkube-api-server       | hmctspublic.azurecr.io/imported/kubeshop/testkube-api-server|
+| kubeshop/testkube-dashboard        | hmctspublic.azurecr.io/imported/kubeshop/testkube-dashboard|
+| kubeshop/testkube-operator         | hmctspublic.azurecr.io/imported/kubeshop/testkube-operator|
+| linuxserver/openssh-server         | hmctspublic.azurecr.io/imported/linuxserver/openssh-server|
+| mailhog/mailhog                    | hmctspublic.azurecr.io/imported/mailhog/mailhog          |
+| minio/minio                        | hmctspublic.azurecr.io/imported/minio/minio              |
+| nats                               | hmctspublic.azurecr.io/imported/nats                    |
+| natsio/nats-server-config-reloader | hmctspublic.azurecr.io/imported/natsio/nats-server-config-reloader|
+| natsio/prometheus-nats-exporter    | hmctspublic.azurecr.io/imported/natsio/prometheus-nats-exporter|
+| neuvector/controller               | hmctspublic.azurecr.io/imported/neuvector/controller    |
+| neuvector/enforcer                 | hmctspublic.azurecr.io/imported/neuvector/enforcer      |
+| neuvector/manager                  | hmctspublic.azurecr.io/imported/neuvector/manager       |
+| neuvector/updater                  | hmctspublic.azurecr.io/imported/neuvector/updater       |
+| netboxcommunity/netbox             | hmctspublic.azurecr.io/imported/netboxcommunity/netbox  |
+| nginx                              | hmctspublic.azurecr.io/imported/nginx                   |
+| otel/opentelemetry-collector-contrib| hmctspublic.azurecr.io/imported/otel/opentelemetry-collector/contrib|
+| prom/node-exporter                 | hmctspublic.azurecr.io/imported/prom/node-exporter       |
+| traefik                            | hmctspublic.azurecr.io/imported/traefik                 |
+| willwill/kube-slack                | hmctspublic.azurecr.io/imported/willwill/kube-slack     |
 
 ### ACR Cache Rules
 The pipeline will also add ACR Cache Rules into hmctspublic registry.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ To create a new ACR cache rule on a repository you need to amend the [yaml file]
 Below is a table of upstream image repositories that will have supported cache rules in hmctspublic. No image tags are added by default, but will be added on the first running instance of `docker pull hmctspublic.azurecr.io/${destinationRepo}:image-tag`, where destinationRepo is the [mapped repository in our ACR for the upstream repository](acr-respositories.yaml), any upstream image tag is available.
 
 
-| Upstream Repository Name  | HMCTS Repository Name|
+| **Upstream Repository Name**  | **HMCTS Repository Name** |
 | -------- | ------- |
 | bitnami/postgresql  | imported/bitnami/postgresql    |

--- a/README.md
+++ b/README.md
@@ -1,17 +1,23 @@
 # acr-base-importer
 Pipelines to automatically import updates to base images and scan them for vulnerabilities
 
-# ACR Cache
-The pipeline will also create ACR Caches into hmctspublic registry.
+# ACR Cache Rules
+The pipeline will also add ACR Cache Rules into hmctspublic registry.
 
-To create a new ACR cache on a repository you need to amend the acr-repositories.yaml file, to add the required details of the new cache. You need to add the following block of code, replacing the values of the parameters with the one you need creating. The below is just an example of an existing ACR Cache
+To create a new ACR cache rule on a repository you need to amend the [yaml file](acr-repositories.yaml), to add the required details of the new cache rule. You need to add the following block of code, replacing the values of the parameters with the one you need creating. The below is just an example of an existing ACR Cache rule
  
  ```
   jenkins: # this can be the same as the name of the repository
     ruleName: Jenkins # the name of the cache rule
-    repoName: hmcts/jenkins # the name of the repository
-    destinationRepo: jenkins # destination repository as it appears in the ACR Cache
-    tagVersion: "75c3e8818c" # The version of the image you need to pull into the Cache; before the image can be used in the cache it needs to be pulled into it by the pipeline
-```
+    repoName: hmcts/jenkins # the name of the repository the image is currently stored in
+    destinationRepo: jenkins # destination repository as it appears in the ACR Cache, will not be visibile until first instance of docker pull command
+ ```
 
-The pipeline will also pull the docker image with the tag specified above into the cache.
+# Supported Upstream Image Repositories
+
+Below is a table of upstream image repositories that will have supported cache rules in hmctspublic. No image tags are added by default, but will be added on the first running instance of `docker pull hmctspublic.azurecr.io/${destinationRepo}:image-tag`, where destinationRepo is the [mapped repository in our ACR for the upstream repository](acr-respositories.yaml), any upstream image tag is available.
+
+
+| Upstream Repository Name  | HMCTS Repository Name|
+| -------- | ------- |
+| bitnami/postgresql  | imported/bitnami/postgresql    |

--- a/acr-cache.sh
+++ b/acr-cache.sh
@@ -11,11 +11,7 @@ for key in $(echo $RULES_CONFIG | jq -r '.rules | keys | .[]'); do
     RULE_NAME=$(echo $RULES_CONFIG | jq -r '.rules | ."'$key'" | .ruleName')
     REPO_NAME=$(echo $RULES_CONFIG | jq -r '.rules | ."'$key'" | .repoName')
     DESTINATION_NAME=$(echo $RULES_CONFIG | jq -r '.rules | ."'$key'" | .destinationRepo')
-    TAG_VERSION=$(echo $RULES_CONFIG | jq -r '.rules | ."'$key'" | .tagVersion')
 
-    echo "Creating ACR Cache for $key"
+    echo "Creating ACR Cache Rule for $key"
     az acr cache create -r hmctspublic -n $RULE_NAME -s docker.io/$REPO_NAME -t $DESTINATION_NAME
-
-    echo "Docker Image Pull"
-    docker pull hmctspublic.azurecr.io/$DESTINATION_NAME:$TAG_VERSION
 done

--- a/acr-repositories.yaml
+++ b/acr-repositories.yaml
@@ -1,6 +1,7 @@
+# Please update README.md with each new unique repoName added to this file as it represents another supported upstream image repository
+
 rules:
   postgresql:
     ruleName: postgresql
     repoName: bitnami/postgresql
     destinationRepo: imported/bitnami/postgresql
-    tagVersion: 11.16.0

--- a/acr-repositories.yaml
+++ b/acr-repositories.yaml
@@ -125,7 +125,3 @@ rules:
     ruleName: kube-slack
     repoName: willwill/kube-slack
     destinationRepo: imported/willwill/kube-slack
-
-
-
-

--- a/acr-repositories.yaml
+++ b/acr-repositories.yaml
@@ -5,3 +5,127 @@ rules:
     ruleName: postgresql
     repoName: bitnami/postgresql
     destinationRepo: imported/bitnami/postgresql
+  external-dns:
+    ruleName: external-dns
+    repoName: bitnami/external-dns
+    destinationRepo: imported/bitnami/external-dns
+  kubectl:
+    ruleName: kubectl
+    repoName: bitnami/kubectl
+    destinationRepo: imported/bitnami/kubectl
+  redis:
+    ruleName: redis
+    repoName: bitnami/redis
+    destinationRepo: imported/bitnami/redis
+  pact-broker:
+    ruleName: pact-broker
+    repoName: dius/pact-broker
+    destinationRepo: imported/dius/pact-broker
+  tel2:
+    ruleName: tel2
+    repoName: datawire/tel2
+    destinationRepo: imported/datawire/tel2
+  service-catalog:
+    ruleName: service-catalog
+    repoName: drycc/service-catalog
+    destinationRepo: imported/drycc/service-catalog
+  dynatrace-operator:
+    ruleName: dynatrace-operator
+    repoName: dynatrace/dynatrace-operator
+    destinationRepo: imported/dynatrace/dynatrace-operator
+  fluent-bit:
+    ruleName: fluent-bit
+    repoName: fluent/fluent-bit
+    destinationRepo: imported/fluent/fluent-bit
+  grafana:
+    ruleName: grafana
+    repoName: grafana/grafana
+    destinationRepo: imported/grafana
+  testkube-api-server:
+    ruleName: testkube-api-server
+    repoName: kubeshop/testkube-api-server
+    destinationRepo: imported/kubeshop/testkube-api-server
+  testkube-dashboard:
+    ruleName: testkube-dashboard
+    repoName: kubeshop/testkube-dashboard
+    destinationRepo: imported/kubeshop/testkube-dashboard
+  testkube-operator:
+    ruleName: testkube-operator
+    repoName: kubeshop/testkube-operator
+    destinationRepo: imported/kubeshop/testkube-operator
+  minio:
+    ruleName: minio
+    repoName: minio/minio
+    destinationRepo: imported/minio/minio
+  neuvector-controller:
+    ruleName: nuevector-controller
+    repoName: neuvector/controller
+    destinationRepo: imported/neuvector/controller
+  neuvector-enforcer:
+    ruleName: nuevector-enforcer
+    repoName: neuvector/enforcer
+    destinationRepo: imported/neuvector/enforcer
+  neuvector-manager:
+    ruleName: nuevector-manager
+    repoName: neuvector/manager
+    destinationRepo: imported/neuvector/manager
+  neuvector-scanner:
+    ruleName: nuevector-scanner
+    repoName: neuvector/updater
+    destinationRepo: imported/neuvector/updater
+  traefik:
+    ruleName: traefik
+    repoName: traefik
+    destinationRepo: imported/traefik
+  configmap-reload:
+    ruleName: configmap-reload
+    repoName: jimmidyson/configmap-reload
+    destinationRepo: imported/jimmidyson/configmap-reload
+  k8s-sidecar:
+    ruleName: k8s-sidecar
+    repoName: kiwigrid/k8s-sidecar
+    destinationRepo: imported/kiwigrid/k8s-sidecar
+  openssh-server:
+    ruleName: openssh-server
+    repoName: linuxserver/openssh-server
+    destinationRepo: imported/linuxserver/openssh-server
+  mailhog:
+    ruleName: mailhog
+    repoName: mailhog/mailhog
+    destinationRepo: imported/mailhog/mailhog
+  nats:
+    ruleName: nats
+    repoName: nats
+    destinationRepo: imported/nats
+  nats-server-config-reloader:  
+    ruleName: nats-server-config-reloader
+    repoName: natsio/nats-server-config-reloader
+    destinationRepo: imported/natsio/nats-server-config-reloader
+  prometheus-nats-exporter:  
+    ruleName: prometheus-nats-exporter
+    repoName: natsio/prometheus-nats-exporter
+    destinationRepo: imported/natsio/prometheus-nats-exporter
+  netbox:  
+    ruleName: netbox
+    repoName: netboxcommunity/netbox
+    destinationRepo: imported/netboxcommunity/netbox
+  nginx:  
+    ruleName: nginx
+    repoName: nginx
+    destinationRepo: imported/nginx
+  opentelemtry-collector:  
+    ruleName: opentelemetry-collector
+    repoName: otel/opentelemetry-collector-contrib
+    destinationRepo: imported/otel/opentelemetry-collector-contrib
+  node-exporter:  
+    ruleName: node-exporter
+    repoName: prom/node-exporter
+    destinationRepo: imported/prom/node-exporter
+  kube-slack:  
+    ruleName: kube-slack
+    repoName: willwill/kube-slack
+    destinationRepo: imported/willwill/kube-slack
+
+
+
+


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-14807


Remove: 
  - Image tag functionality as discussed in https://github.com/hmcts/acr-base-importer/pull/51 -- not needed as it automatically pulls through when docker pull command used
  - Documentation related to ^

Update:
  - Add table of supported upstream repos
  - README to reflect code changes
 
Add:
  - Image repositories that need to be cached in our ACR according to spike work




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
