### PR TITLE
Update back to serviceconnection for other jobs besides cache

### DIFF
--- a/base-image-import.yml
+++ b/base-image-import.yml
@@ -16,7 +16,8 @@ variables:
   acrName: hmctspublic
   targetRegistry: hmctspublic.azurecr.io
   keyvaultName: 'infra-vault-prod'
-  serviceConnection: 'DCD-CNP-PROD'
+  serviceConnection: 'azurerm-prod'
+  cacheServiceConnection: 'DCD-CNP-PROD'
   keyvaultNameStg: 'cftapps-stg'
   serviceConnectionStg: 'DCD-CFTAPPS-STG'
   neuvectorController: 'https://neuvector01-api.aat.platform.hmcts.net'
@@ -149,6 +150,6 @@ jobs:
     - task: AzureCLI@1
       displayName: 'Create ACR Cache'
       inputs:
-        azureSubscription: $(serviceConnection)
+        azureSubscription: $(cacheServiceConnection)
         scriptLocation: 'scriptPath'
         scriptPath: acr-cache.sh


### PR DESCRIPTION
Jobs on main branch are currently failing without access to the specified vault, which wasn't happening before service connection change.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
