### PR TITLE
Add repo name williamyeh/java8

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Below is a table of upstream image repositories that will have supported cache r
 | `toolbelt/oathtool`                    | `hmctspublic.azurecr.io/imported/toolbelt/oathtool`                    |
 | `traefik`                              | `hmctspublic.azurecr.io/imported/traefik`                              |
 | `willwill/kube-slack`                  | `hmctspublic.azurecr.io/imported/willwill/kube-slack`                  |
+| `williamyeh/java8`                     | `hmctspublic.azurecr.io/imported/williamyeh/java8`                     |
 
 ### ACR Cache Rules
 The pipeline will also add ACR Cache Rules into hmctspublic registry.

--- a/acr-repositories.yaml
+++ b/acr-repositories.yaml
@@ -162,3 +162,7 @@ rules:
     ruleName: redis
     repoName: library/redis
     destinationRepo: imported/redis
+  williamyeh-java8:
+    ruleName: williamyeh-java8
+    repoName: williamyeh/java8
+    destinationRepo: imported/williamyeh/java8


### PR DESCRIPTION
### Jira link (if applicable

N/A

### Change description ###

Add a repo williamyeh/java8. The DARTS project requires this image as part of its integration test effort. The image simply creates load a linux platform with java 1.8 installed.
