### PR TITLE
NO-JIRA: Include debian bookworm and bullseye

### DIFF
--- a/base-image-import.yml
+++ b/base-image-import.yml
@@ -48,7 +48,16 @@ jobs:
         baseRegistry: gcr.io
         baseTag: debug
         targetImage: imported/distroless/java17
-
+      openjdk-21-jdk-slim-bullseye:
+        baseImage: openjdk:21-jdk-slim-bullseye
+        baseRegistry: gcr.io
+        baseTag: latest
+        targetImage: imported/slim-bullseye/java21
+      openjdk-21-jdk-slim-bookworm:
+        baseImage: openjdk:21-jdk-slim-bookworm
+        baseRegistry: gcr.io
+        baseTag: latest
+        targetImage: imported/slim-bookworm/java21
   steps:
   - task: AzureKeyVault@1
     displayName: 'Get secrets from Keyvault'


### PR DESCRIPTION
### Jira link

N/A

### Change description

I am seeing docker rate limiting failures when building my branch (https://sds-build.hmcts.net/job/HMCTS/job/darts-proxy/job/PR-135/6/console).

This PR is a change so that we can reference google docker registry instead.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
