### PR TITLE
Import wiremock to acr

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Below is a table of upstream image repositories that will have supported cache r
 | `traefik`                              | `hmctspublic.azurecr.io/imported/traefik`                              |
 | `willwill/kube-slack`                  | `hmctspublic.azurecr.io/imported/willwill/kube-slack`                  |
 | `williamyeh/java8`                     | `hmctspublic.azurecr.io/imported/williamyeh/java8`                     |
+| `wiremock/wiremock`                    | `hmctspublic.azurecr.io/imported/wiremock/wiremock`                    |
 | `azure-storage/azurite`                | `hmctspublic.azurecr.io/imported/azure-storage/azurite`                |
 | `atmoz/sftp`                           | `hmctspublic.azurecr.io/imported/atmoz/sftp`                           |
 | `citizensadvice/clamav-mock`           | `hmctspublic.azurecr.io/imported/citizensadvice/clamav-mock`           |

--- a/acr-repositories.yaml
+++ b/acr-repositories.yaml
@@ -199,3 +199,7 @@ rules:
     ruleName: mikefarah-yq
     repoName: mikefarah/yq
     destinationRepo: imported/mikefarah/yq
+  wiremock:
+    ruleName: wiremock
+    repoName: wiremock/wiremock
+    destinationRepo: imported/wiremock/wiremock


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-26946

### Change description

Adding docker image wiremock/wiremock to public ACR
