### PR TITLE
DTSPO-30331: add helm/ to start of repo path for chart sync action

### DIFF
--- a/helm-charts.yaml
+++ b/helm-charts.yaml
@@ -6,7 +6,7 @@ charts:
     repo_url: https://kubernetes-sigs.github.io/external-dns/
     repo_name: external-dns-chart  # Local name for 'helm repo add'
     chart_name: external-dns  # The upstream chart name
-    acr_repository: imported/k8s-sigs/external-dns-chart  # Full repository path in ACR
+    acr_repository: helm/imported/k8s-sigs/external-dns-chart  # Full repository path in ACR
     acr_registries:
       - hmctspublic
       - hmctsprod


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-30331

### Change description

- add helm/ to start of repo path as its default for oci repos for helm controller flux

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
