### PR TITLE
add ruby cache

### DIFF
--- a/acr-repositories.yaml
+++ b/acr-repositories.yaml
@@ -241,3 +241,8 @@ rules:
     repoName: external-dns/external-dns
     registry: registry.k8s.io
     destinationRepo: imported/k8s-sigs/external-dns
+  ruby:
+    ruleName: ruby
+    repoName: library/ruby
+    registry: docker.io
+    destinationRepo: imported/library/ruby


### PR DESCRIPTION
### Change description

tax-tribunals is often seeing the following error 

>  Step 1/74 : FROM ruby:3.4.8-alpine3.23
>  toomanyrequests: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit

looking at the readme I can see ruby is mentioned to be cached, however i was unable to find the ruby cache rule so adding it here. 
