### PR TITLE
fix ruby cache name

### DIFF
--- a/acr-repositories.yaml
+++ b/acr-repositories.yaml
@@ -242,7 +242,7 @@ rules:
     registry: registry.k8s.io
     destinationRepo: imported/k8s-sigs/external-dns
   ruby:
-    ruleName: ruby
+    ruleName: ruby-cache
     repoName: library/ruby
     registry: docker.io
     destinationRepo: imported/library/ruby


### PR DESCRIPTION
### Change description

pull request #130 created the ruby cache, however this failed due to azure requiring the cache name to be at least 5 and less than 50 characters